### PR TITLE
fix: stable sort order between large and xlarge instance types

### DIFF
--- a/scripts/generate-ec2-types.ts
+++ b/scripts/generate-ec2-types.ts
@@ -108,7 +108,7 @@ const getSizeOrderIndex = (size: string) => {
     return 10_000 + (!isNaN(metalUnits) ? metalUnits : 0);
   }
   if (size.endsWith('xlarge')) {
-    return smallSizeOrder.length - 1 + parseInt(size.match(/(\d{1,})?xlarge/)?.[1] || '0');
+    return smallSizeOrder.length - 1 + parseInt(size.match(/(\d{1,})?xlarge/)?.[1] || '1');
   }
   return smallSizeOrder.indexOf(size);
 };


### PR DESCRIPTION
Change xlarge fallback from '0' to '1' in getSizeOrderIndex so bare xlarge maps to index 5 instead of 4, avoiding collision with large and ensuring deterministic output from the generate script.