### PR TITLE
ci: fix yarn cache path lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         shell: bash
-        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v5
         id: yarn-cache


### PR DESCRIPTION
## What changed

Replaced the release workflow cache path lookup from `yarn cache dir` to `yarn config get cacheFolder`.

## Why

The prior change only modernized GitHub Actions output syntax from deprecated `::set-output` to `$GITHUB_OUTPUT`, but it kept the existing Yarn command. This repository uses Yarn 4, where `yarn cache dir` is no longer available, causing the release workflow to fail before the cache step.

## Validation

- Ran `yarn config get cacheFolder` locally and confirmed it returns the cache directory.
- Parsed `.github/workflows/release.yml` with the repo's Node YAML parser.
- Ran `git diff --check`.